### PR TITLE
More featured uncompressed SVG

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ The following variables can be set in the Pelican settings file:
 
 - `GRAPHVIZ_BLOCK_START`: Starting tag for the Graphviz block in Markdown (defaults to `'..graphviz'`).
 
+- `GRAPHVIZ_COMPRESS`: Compresses the SVG XML to an image, without compression more SVG features are available (defaults to `True`).
+
 
 Output Image Format
 -------------------

--- a/pelican/plugins/graphviz/graphviz.py
+++ b/pelican/plugins/graphviz/graphviz.py
@@ -31,11 +31,13 @@ def initialize(pelicanobj):
     pelicanobj.settings.setdefault("GRAPHVIZ_BLOCK_START", "..graphviz")
     pelicanobj.settings.setdefault("GRAPHVIZ_IMAGE_CLASS", "graphviz")
     pelicanobj.settings.setdefault("GRAPHVIZ_HTML_ELEMENT", "div")
+    pelicanobj.settings.setdefault("GRAPHVIZ_COMPRESS", True)
 
     config = {
         "block-start": pelicanobj.settings.get("GRAPHVIZ_BLOCK_START"),
         "image-class": pelicanobj.settings.get("GRAPHVIZ_IMAGE_CLASS"),
         "html-element": pelicanobj.settings.get("GRAPHVIZ_HTML_ELEMENT"),
+        "compress": pelicanobj.settings.get("GRAPHVIZ_COMPRESS"),
     }
 
     if isinstance(

--- a/pelican/plugins/graphviz/mdx_graphviz.py
+++ b/pelican/plugins/graphviz/mdx_graphviz.py
@@ -137,7 +137,8 @@ class GraphvizProcessor(BlockProcessor):
             img = etree.SubElement(elt, "img")
             img.set(
                 "src",
-                "data:image/svg+xml;base64,%s" % base64.b64encode(output).decode("ascii"),
+                "data:image/svg+xml;base64,%s"
+                % base64.b64encode(output).decode("ascii"),
             )
         else:
             svg = output.decode()

--- a/pelican/plugins/graphviz/mdx_graphviz.py
+++ b/pelican/plugins/graphviz/mdx_graphviz.py
@@ -133,11 +133,16 @@ class GraphvizProcessor(BlockProcessor):
 
         elt = etree.SubElement(parent, self.config["html-element"])
         elt.set("class", self.config["image-class"])
-        img = etree.SubElement(elt, "img")
-        img.set(
-            "src",
-            "data:image/svg+xml;base64,%s" % base64.b64encode(output).decode("ascii"),
-        )
+        if self.config["compress"]:
+            img = etree.SubElement(elt, "img")
+            img.set(
+                "src",
+                "data:image/svg+xml;base64,%s" % base64.b64encode(output).decode("ascii"),
+            )
+        else:
+            svg = output.decode()
+            start = svg.find("<svg")
+            elt.text = "\n" + svg[start:]
 
 
 class GraphvizExtension(Extension):

--- a/pelican/plugins/graphviz/test_graphviz.py
+++ b/pelican/plugins/graphviz/test_graphviz.py
@@ -31,7 +31,7 @@ TEST_DIR_PREFIX = "pelicantests."
 GRAPHVIZ_RE = (
     r'<{0} class="{1}"><img src="data:image/svg\+xml;base64,[0-9a-zA-Z+=]+"></{0}>'
 )
-GRAPHVIZ_RE_XML = r'<\?xml version='
+GRAPHVIZ_RE_XML = r'<svg width="170pt" height="44pt"'
 
 
 class TestGraphviz(unittest.TestCase):

--- a/pelican/plugins/graphviz/test_graphviz.py
+++ b/pelican/plugins/graphviz/test_graphviz.py
@@ -38,7 +38,10 @@ class TestGraphviz(unittest.TestCase):
     """Class for testing the URL output of the Graphviz plugin"""
 
     def setUp(
-        self, block_start="..graphviz", image_class="graphviz", html_element="div",
+        self,
+        block_start="..graphviz",
+        image_class="graphviz",
+        html_element="div",
         compress=True,
     ):
 
@@ -99,7 +102,9 @@ digraph G {
         # to the generated Graphviz figure
         for line in fid.readlines():
             if self.settings["GRAPHVIZ_COMPRESS"]:
-                if re.search(GRAPHVIZ_RE.format(self.html_element, self.image_class), line):
+                if re.search(
+                    GRAPHVIZ_RE.format(self.html_element, self.image_class), line
+                ):
                     found = True
                     break
             else:
@@ -142,6 +147,7 @@ class TestGraphvizImageClass(TestGraphviz):
     def test_output(self):
         """Test for GRAPHVIZ_IMAGE_CLASS setting"""
         TestGraphviz.test_output(self)
+
 
 class TestGraphvizImageNoCompress(TestGraphviz):
     """Class for exercising configuration variable GRAPHVIZ_COMPRESS"""

--- a/pelican/plugins/graphviz/test_graphviz.py
+++ b/pelican/plugins/graphviz/test_graphviz.py
@@ -96,7 +96,9 @@ digraph G {
     def test_output(self):
         """Test for default values of the configuration variables"""
         # Open the output HTML file
-        content = open(os.path.join(self.output_path, "%s.html" % TEST_FILE_STEM)).read()
+        content = open(
+            os.path.join(self.output_path, "%s.html" % TEST_FILE_STEM)
+        ).read()
         found = False
         # Iterate over the lines and look for the HTML element corresponding
         # to the generated Graphviz figure

--- a/pelican/plugins/graphviz/test_graphviz.py
+++ b/pelican/plugins/graphviz/test_graphviz.py
@@ -31,7 +31,7 @@ TEST_DIR_PREFIX = "pelicantests."
 GRAPHVIZ_RE = (
     r'<{0} class="{1}"><img src="data:image/svg\+xml;base64,[0-9a-zA-Z+=]+"></{0}>'
 )
-GRAPHVIZ_RE_XML = r'<svg width="170pt" height="44pt"'
+GRAPHVIZ_RE_XML = r'<svg width="\d+pt" height="\d+pt"'
 
 
 class TestGraphviz(unittest.TestCase):

--- a/pelican/plugins/graphviz/test_graphviz.py
+++ b/pelican/plugins/graphviz/test_graphviz.py
@@ -112,6 +112,7 @@ digraph G {
             else:
                 if re.search(GRAPHVIZ_RE_XML, line):
                     found = True
+                    break
         assert found, content
 
 

--- a/pelican/plugins/graphviz/test_graphviz.py
+++ b/pelican/plugins/graphviz/test_graphviz.py
@@ -96,11 +96,11 @@ digraph G {
     def test_output(self):
         """Test for default values of the configuration variables"""
         # Open the output HTML file
-        fid = open(os.path.join(self.output_path, "%s.html" % TEST_FILE_STEM))
+        content = open(os.path.join(self.output_path, "%s.html" % TEST_FILE_STEM)).read()
         found = False
         # Iterate over the lines and look for the HTML element corresponding
         # to the generated Graphviz figure
-        for line in fid.readlines():
+        for line in content.splitlines():
             if self.settings["GRAPHVIZ_COMPRESS"]:
                 if re.search(
                     GRAPHVIZ_RE.format(self.html_element, self.image_class), line
@@ -110,7 +110,7 @@ digraph G {
             else:
                 if re.search(GRAPHVIZ_RE_XML, line):
                     found = True
-        assert found
+        assert found, content
 
 
 class TestGraphvizHtmlElement(TestGraphviz):


### PR DESCRIPTION
in the basic example, the graph is simple. We can slightly complicate it and see that some features are not available with the current plugin version. 

```
..graphviz dot
digraph G {
  graph [rankdir = LR];
  Hello [URL="https://google.com"];
  Hello -> World
}
```

the image is not clickable, however, raw SVG output is clickable and it makes a big difference

An additional option unlocks uncompressed SVG to be inserted into an HTML

```
GRAPHVIZ_COMPRESS = False
```