### PR TITLE
Fixup lint and test

### DIFF
--- a/pelican/plugins/graphviz/mdx_graphviz.py
+++ b/pelican/plugins/graphviz/mdx_graphviz.py
@@ -48,7 +48,9 @@
 
 import base64
 import errno
+import os
 import re
+from subprocess import PIPE, Popen
 import xml.etree.ElementTree as ET
 
 from markdown import Extension
@@ -65,9 +67,6 @@ class DotRuntimeError(RuntimeError):
 
 def run_graphviz(program, code, options=None, format="png"):
     """Run graphviz program and returns image data."""
-    import os
-    from subprocess import PIPE, Popen
-
     if not options:
         options = []
 

--- a/pelican/plugins/graphviz/mdx_graphviz.py
+++ b/pelican/plugins/graphviz/mdx_graphviz.py
@@ -183,7 +183,12 @@ class GraphvizProcessor(BlockProcessor):
                     r"<!-- Title: (.*) Pages: \d+ -->",
                     output.decode("utf-8"),
                 )
-                if m:
+                # Gating against a matched title of "%3" works around an old
+                # graphviz issue, which is still present in the version
+                # shipped with Ubuntu 24.04:
+                #
+                # https://gitlab.com/graphviz/graphviz/-/issues/1376
+                if m and m.group(1) != "%3":
                     img.set("alt", m.group(1))
                 else:
                     img.set("alt", config["alt-text-default"])

--- a/pelican/plugins/graphviz/test_graphviz.py
+++ b/pelican/plugins/graphviz/test_graphviz.py
@@ -218,24 +218,20 @@ class TestGraphvizAltText(TestGraphviz):
         TestGraphviz.test_output(self)
 
 
-# This test is commented out because it fails in the GitHub action, even
-# though it works fine locally. For some strange reason, the alt property
-# is set to "%3", instead of "foo". This should be investigated further.
-#
-# class TestGraphvizAltTextWithoutID(TestGraphviz):
-#     """Class for testing the case where the Graphviz element has no id."""
-#
-#     def setUp(self):
-#         """Initialize the configuration."""
-#         TestGraphviz.setUp(
-#             self,
-#             digraph_id=None,
-#             alt_text="foo",
-#         )
-#
-#     def test_output(self):
-#         """Test for GRAPHVIZ_IMAGE_CLASS setting."""
-#         TestGraphviz.test_output(self)
+class TestGraphvizAltTextWithoutID(TestGraphviz):
+    """Class for testing the case where the Graphviz element has no id."""
+
+    def setUp(self):
+        """Initialize the configuration."""
+        TestGraphviz.setUp(
+            self,
+            digraph_id=None,
+            alt_text="foo",
+        )
+
+    def test_output(self):
+        """Test for GRAPHVIZ_IMAGE_CLASS setting."""
+        TestGraphviz.test_output(self)
 
 
 class TestGraphvizAltTextViaOption(TestGraphviz):

--- a/pelican/plugins/graphviz/test_graphviz.py
+++ b/pelican/plugins/graphviz/test_graphviz.py
@@ -28,7 +28,10 @@ from . import graphviz
 
 TEST_FILE_STEM = "test"
 TEST_DIR_PREFIX = "pelicantests."
-GRAPHVIZ_RE = r'<{0} class="{1}"><img alt="{2}" src="data:image/svg\+xml;base64,[0-9a-zA-Z+=]+"></{0}>'
+GRAPHVIZ_RE = (
+    r'<{0} class="{1}"><img alt="{2}" '
+    r'src="data:image/svg\+xml;base64,[0-9a-zA-Z+=]+"></{0}>'
+)
 
 GRAPHVIZ_RE_XML = r'<svg width="\d+pt" height="\d+pt"'
 
@@ -213,6 +216,7 @@ class TestGraphvizAltText(TestGraphviz):
     def test_output(self):
         """Test for GRAPHVIZ_IMAGE_CLASS setting."""
         TestGraphviz.test_output(self)
+
 
 # This test is commented out because it fails in the GitHub action, even
 # though it works fine locally. For some strange reason, the alt property


### PR DESCRIPTION
This fixes lint and test errors that were previously failing on GitHub Actions. TestGraphvizAltTextWithoutID is re-enabled, with a workaround for a bug in the very old version of graphviz still shipped in Ubuntu 24.04.

This PR is a prelude to me trying my hand at implementing reStructuredText support, but hopefully these fixes will be useful regardless of whether that feature lands.