### PR TITLE
Refactor tests for RST support

### DIFF
--- a/pelican/plugins/graphviz/test_graphviz.py
+++ b/pelican/plugins/graphviz/test_graphviz.py
@@ -151,9 +151,10 @@ class TestGraphvizBlockStart(TestGraphviz):
 
     def setUp(self):
         """Initialize the configuration."""
+        value = "==foobar"
         super().setUp(
-            config={"md_block_start": "==foobar"},
-            settings={"GRAPHVIZ_BLOCK_START": "==foobar"},
+            config={"md_block_start": value},
+            settings={"GRAPHVIZ_BLOCK_START": value},
         )
 
 

--- a/pelican/plugins/graphviz/test_graphviz.py
+++ b/pelican/plugins/graphviz/test_graphviz.py
@@ -148,10 +148,6 @@ class TestGraphvizHtmlElement(TestGraphviz):
         """Initialize the configuration."""
         TestGraphviz.setUp(self, html_element="span")
 
-    def test_output(self):
-        """Test for GRAPHVIZ_HTML_ELEMENT setting."""
-        TestGraphviz.test_output(self)
-
 
 class TestGraphvizBlockStart(TestGraphviz):
     """Class for exercising the configuration variable GRAPHVIZ_BLOCK_START."""
@@ -159,10 +155,6 @@ class TestGraphvizBlockStart(TestGraphviz):
     def setUp(self):
         """Initialize the configuration."""
         TestGraphviz.setUp(self, block_start="==foobar")
-
-    def test_output(self):
-        """Test for GRAPHVIZ_BLOCK_START setting."""
-        TestGraphviz.test_output(self)
 
 
 class TestGraphvizImageClass(TestGraphviz):
@@ -172,10 +164,6 @@ class TestGraphvizImageClass(TestGraphviz):
         """Initialize the configuration."""
         TestGraphviz.setUp(self, image_class="foo")
 
-    def test_output(self):
-        """Test for GRAPHVIZ_IMAGE_CLASS setting."""
-        TestGraphviz.test_output(self)
-
 
 class TestGraphvizImageNoCompress(TestGraphviz):
     """Class for exercising configuration variable GRAPHVIZ_COMPRESS."""
@@ -183,10 +171,6 @@ class TestGraphvizImageNoCompress(TestGraphviz):
     def setUp(self):
         """Initialize the configuration."""
         TestGraphviz.setUp(self, compress=False)
-
-    def test_output(self):
-        """Test for GRAPHVIZ_COMPRESS setting."""
-        TestGraphviz.test_output(self)
 
 
 class TestGraphvizLocallyOverrideConfiguration(TestGraphviz):
@@ -201,10 +185,6 @@ class TestGraphvizLocallyOverrideConfiguration(TestGraphviz):
             expected_html_element="span",
         )
 
-    def test_output(self):
-        """Test for overrind the configuration."""
-        TestGraphviz.test_output(self)
-
 
 class TestGraphvizAltText(TestGraphviz):
     """Class for exercising configuration variable GRAPHVIZ_ALT_TEXT."""
@@ -212,10 +192,6 @@ class TestGraphvizAltText(TestGraphviz):
     def setUp(self):
         """Initialize the configuration."""
         TestGraphviz.setUp(self, alt_text="foo")
-
-    def test_output(self):
-        """Test for GRAPHVIZ_IMAGE_CLASS setting."""
-        TestGraphviz.test_output(self)
 
 
 class TestGraphvizAltTextWithoutID(TestGraphviz):
@@ -229,10 +205,6 @@ class TestGraphvizAltTextWithoutID(TestGraphviz):
             alt_text="foo",
         )
 
-    def test_output(self):
-        """Test for GRAPHVIZ_IMAGE_CLASS setting."""
-        TestGraphviz.test_output(self)
-
 
 class TestGraphvizAltTextViaOption(TestGraphviz):
     """Class for testing the alternative text given via the alt-text option."""
@@ -245,7 +217,3 @@ class TestGraphvizAltTextViaOption(TestGraphviz):
             options=f'alt-text="{text}"',
             expected_alt_text=text,
         )
-
-    def test_output(self):
-        """Test for GRAPHVIZ_IMAGE_CLASS setting."""
-        TestGraphviz.test_output(self)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ lint = [
     "ruff>=0.9.1,<1.0.0",
 ]
 test = [
+    "beautifulsoup4>=4.13",
     "invoke>=2.2",
     "markdown>=3.4",
     "pytest>=7.0",


### PR DESCRIPTION
Stacked on top of #33 

For #32, this modifies the existing tests to make them more amenable to supporting reStructuredText in addition to Markdown. At a high level:

- Expected values are no longer determined implicitly within `TestGraphviz`, rather given explicitly in test cases alongside options and settings. I believe this will make the tests easier to read when RST support is added.
- A `test_md` method is factored out of `TestGraphviz`, such that a corresponding `test_rst` can be added later.
- BeautifulSoup is used to verify output, making the tests less dependent on the exact textual order of HTML attributes in the output. This helps with later adding RST support.

Given the changes to `test_output`, I verified the new behavior by intentionally breaking some pre-existing test cases and making sure they would actually fail if incorrect.