### PR TITLE
Implement RST directive for graphviz

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Graphviz: A Plugin for Pelican
 [![Downloads](https://img.shields.io/pypi/dm/pelican-graphviz)](https://pypi.org/project/pelican-graphviz/)
 [![License](https://img.shields.io/pypi/l/pelican-graphviz?color=blue)](https://www.gnu.org/licenses/agpl-3.0.en.html)
 
-Graphviz is a Pelican plugin that allows the inclusion of [Graphviz][] images using the Markdown markup format. The code for the Graphviz figure is included as a block in the article’s source. In the output HTML file, the Graphviz figure can appear as either a `<svg>` or embedded into a `<img>` element using the Base64 format.
+Graphviz is a Pelican plugin that allows the inclusion of [Graphviz][] images using the Markdown or reStructuredText markup format. The code for the Graphviz figure is included as a block in the article’s source. In the output HTML file, the Graphviz figure can appear as either a `<svg>` or embedded into a `<img>` element using the Base64 format.
 
 [Graphviz]: https://www.graphviz.org
 
@@ -32,9 +32,11 @@ For macOS, Graphviz can be installed via Homebrew:
 Usage
 -----
 
-In the Markdown source, the Graphviz code must be inserted as an individual block (i.e., separated from the rest of the material by blank lines), like the following:
+### Markdown
 
-```markdwon
+In Markdown source, the Graphviz code must be inserted as an individual block (i.e., separated from the rest of the material by blank lines), like the following:
+
+```markdown
 ..graphviz dot
 digraph G {
   graph [rankdir = LR];
@@ -50,6 +52,19 @@ The block must start with `..graphviz` (this is configurable — see below). The
 
 [Graphviz documentation]: https://www.graphviz.org/documentation/
 
+### reStructuredText
+
+For RST input, support is implemented as a directive, with syntax like:
+
+```rst
+.. graphviz:: dot
+   :alt-text: My graph
+
+   digraph G {
+     graph [rankdir = LR];
+     Hello -> World
+   }
+```
 
 Styling with CSS
 ----------------
@@ -83,20 +98,29 @@ The following variables can be set in the Pelican settings file:
 
 - `GRAPHVIZ_IMAGE_CLASS`: Class of the `<div>` element including the generated Graphviz image (defaults to `'graphviz'`).
 
-- `GRAPHVIZ_BLOCK_START`: Starting tag for the Graphviz block in Markdown (defaults to `'..graphviz'`).
+- `GRAPHVIZ_BLOCK_START`: Starting tag for the Graphviz block in Markdown (defaults to `'..graphviz'`).  This setting has no effect for reStructuredText input.
 
 - `GRAPHVIZ_COMPRESS`: Compress the resulting SVG XML to an image (defaults to `True`). Without compression, more SVG features are available, for instance including clickable URLs inside the Graphviz diagram.
 
 - `GRAPHVIZ_ALT_TEXT`: String that will be used as the default value for the `alt` property of the generated `<img>` HTML element (defaults to `"[GRAPH]"`). It is only meaningful when the reuslting SVG output is compressed.
 
-The values above can be overridden for each individual block using the syntax below:
+The values above can be overridden for each individual block using the syntax below. In Markdown, this looks like:
 
-```markdwon
+```markdown
 ..graphviz [key1=val1, key2="val2"...] dot
 ```
-The allowed keys are `html-element`, `image-class`, `block-start`, `alt-text`, and `compress`. For the latter, the value can be either `yes` or `no`.
 
 If the value needs to include a comma (`,`) or an equal sign (`=`), then use the `key2="val2"` form.
+
+Or in reStructuredText:
+
+```rst
+.. graphviz:: dot
+   :key1: val1
+   :key2: val2
+```
+
+The allowed keys are `html-element`, `image-class`, `block-start`, `alt-text`, and `compress`. For the latter, the value can be either `yes` or `no`.  `block-start` has no effect for reStructuredText.
 
 
 Output Image Format
@@ -128,14 +152,6 @@ An alternative to this plugin is the [Graphviz tag][] provided by the [Liquid Ta
 
 [Graphviz tag]: https://github.com/pelican-plugins/liquid-tags/blob/main/pelican/plugins/liquid_tags/graphviz.py
 [Liquid Tags plugin]: https://github.com/pelican-plugins/liquid-tags
-
-
-To-Do
------
-
-Contributions that make this plugin work with [reStructuredText][] content are welcome.
-
-[reStructuredText]: https://docutils.sourceforge.io/rst.html
 
 
 Contributing

--- a/pelican/plugins/graphviz/graphviz.py
+++ b/pelican/plugins/graphviz/graphviz.py
@@ -19,9 +19,12 @@ import logging
 import os
 import subprocess
 
+from docutils.parsers.rst import directives
+
 from pelican import signals
 
 from .mdx_graphviz import GraphvizExtension
+from .rst_graphviz import make_graphviz_directive
 
 logger = logging.getLogger(__name__)
 
@@ -51,6 +54,8 @@ def initialize(pelicanobj):
         pelicanobj.settings["MARKDOWN"].setdefault("extensions", []).append(
             GraphvizExtension(config)
         )
+
+    directives.register_directive("graphviz", make_graphviz_directive(config))
 
 
 def register():

--- a/pelican/plugins/graphviz/rst_graphviz.py
+++ b/pelican/plugins/graphviz/rst_graphviz.py
@@ -29,8 +29,9 @@ from .run_graphviz import append_base64_img, run_graphviz
 def truthy(argument: str) -> bool:
     """Parse a "truthy" RST option.
 
-    Applies permissive conventions to interpret to interpret "truthy"-looking
-    strings as True, or False otherwise.
+    Applies permissive conventions to interpret "truthy"-looking strings as
+    True, or False otherwise.
+
     """
     return argument.lower() in ("yes", "true", "on", "1")
 

--- a/pelican/plugins/graphviz/rst_graphviz.py
+++ b/pelican/plugins/graphviz/rst_graphviz.py
@@ -1,0 +1,90 @@
+"""reStructuredText extension for the Graphviz plugin for Pelican."""
+
+# Copyright (C) 2025  Mark Shroyer <mark@shroyer.name>
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Affero Public License as published by
+# the Free Software Foundation, either version 3 of the License, or (at
+# your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see http://www.gnu.org/licenses/.
+
+import html
+from typing import ClassVar
+import xml.etree.ElementTree as ET
+
+from docutils import nodes
+from docutils.parsers.rst import Directive
+from docutils.parsers.rst.directives import unchanged
+
+from .run_graphviz import append_base64_img, run_graphviz
+
+
+def truthy(argument: str) -> bool:
+    """Parse a "truthy" RST option.
+
+    Applies permissive conventions to interpret to interpret "truthy"-looking
+    strings as True, or False otherwise.
+    """
+    return argument.lower() in ("yes", "true", "on", "1")
+
+
+def make_graphviz_directive(base_config: dict):
+    """Make a graphviz RST directive incorporating the plugin's configuration.
+
+    Returns a Directive subclass that implements graphviz support, taking into
+    account the plugin's runtime configuration.
+
+    """
+
+    class GraphvizDirective(Directive):
+        """An RST directive for embedded Graphviz.
+
+        Takes the name of a graphviz program, such as dot, as a required
+        argument, and invokes it over the directive's content.  The plugin's
+        configuration can be overridden using directive options.
+
+        """
+
+        required_arguments = 1
+        option_spec: ClassVar = {
+            "image-class": unchanged,
+            "html-element": unchanged,
+            "compress": truthy,
+            "alt-text": unchanged,
+        }
+        has_content = True
+
+        def run(self):
+            config = base_config.copy()
+            config.update(self.options)
+
+            program = self.arguments[0]
+            code = "\n".join(self.content)
+
+            output = run_graphviz(program, code, format="svg")
+
+            elt = ET.Element(config["html-element"])
+            elt.set("class", config["image-class"])
+
+            if config["compress"]:
+                append_base64_img(output, config, elt)
+                img_html = ET.tostring(elt, encoding="unicode", method="html")
+            else:
+                svg = output.decode()
+                start = svg.find("<svg")
+                tag = html.escape(config["html-element"], quote=True)
+                class_ = html.escape(config["image-class"], quote=True)
+                img_html = f'<{tag} class="{class_}">{svg[start:]}</{tag}>'
+
+            svg_node = nodes.raw("", img_html, format="html")
+            container = nodes.container("", svg_node, classes=["graphviz"])
+            return [container]
+
+    return GraphvizDirective

--- a/pelican/plugins/graphviz/test_graphviz.py
+++ b/pelican/plugins/graphviz/test_graphviz.py
@@ -99,6 +99,33 @@ digraph{f" {self.config['digraph_id']}" if self.config["digraph_id"] else ""} {{
         self.run_pelican()
         self.assert_expected_output()
 
+    def test_rst(self):
+        options_string = ""
+        if self.config["options"]:
+            options_string = "\n".join(
+                f"   :{k}: {v}" for k, v in self.config["options"].items()
+            )
+
+        with open(os.path.join(self.content_path, f"{TEST_FILE_STEM}.rst"), "w") as fid:
+            rst_input = f"""\
+{TEST_FILE_STEM}
+################
+:date: 1970-01-01
+:slug: {TEST_FILE_STEM}
+
+.. graphviz:: dot
+{options_string}
+
+   digraph{f" {self.config['digraph_id']}" if self.config["digraph_id"] else ""} {{
+     graph [rankdir = LR];
+     Hello -> World
+   }}
+"""
+            fid.write(rst_input)
+
+        self.run_pelican()
+        self.assert_expected_output()
+
     def run_pelican(self):
         settings = read_settings(override=self.settings)
         pelican = Pelican(settings=settings)
@@ -147,7 +174,13 @@ class TestGraphvizHtmlElement(TestGraphviz):
 
 
 class TestGraphvizBlockStart(TestGraphviz):
-    """Class for exercising the configuration variable GRAPHVIZ_BLOCK_START."""
+    """Class for exercising the configuration variable GRAPHVIZ_BLOCK_START.
+
+    Because the reStructredText implementation does not allow configuring the
+    directive name using GRAPHVIZ_BLOCK_START, test_rst() is essentially a
+    no-op for this test case.
+
+    """
 
     def setUp(self):
         """Initialize the configuration."""

--- a/pelican/plugins/graphviz/test_graphviz.py
+++ b/pelican/plugins/graphviz/test_graphviz.py
@@ -213,6 +213,40 @@ class TestGraphvizImageNoCompress(TestGraphviz):
         )
 
 
+class TestGraphvizImageCompressOptionNo(TestGraphviz):
+    """Class for exercising the compress option set to "no".
+
+    Ensures that a "no" compress option is parsed as False and overrides the
+    setting.
+
+    """
+
+    def setUp(self):
+        """Initialize the configuration."""
+        super().setUp(
+            config={"options": {"compress": "no"}},
+            settings={"GRAPHVIZ_COMPRESS": True},
+            expected={"compressed": False},
+        )
+
+
+class TestGraphvizImageCompressOptionYes(TestGraphviz):
+    """Class for exercising the compress option set to "yes".
+
+    Ensures that a "yes" compress option is parsed as True and overrides the
+    setting.
+
+    """
+
+    def setUp(self):
+        """Initialize the configuration."""
+        super().setUp(
+            config={"options": {"compress": "yes"}},
+            settings={"GRAPHVIZ_COMPRESS": False},
+            expected={"compressed": True},
+        )
+
+
 class TestGraphvizLocallyOverrideConfiguration(TestGraphviz):
     """Class for exercising the override of a configuration variable."""
 


### PR DESCRIPTION
Stacked on top of #34

For #32, this moves some additional shared logic into run_graphviz.py, then implements the reStructuredText directive, enables tests, and documents how to use it in the README.

One limitation here is that as opposed to the Markdown version, the directive name is not currently configurable. I could add that if you'd like, but maybe it'd have to be a different setting name, since the Markdown block setting includes the leading dots?