### PR TITLE
chore: Apply upstream template changes via Cruft

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/getpelican/cookiecutter-pelican-plugin",
-  "commit": "8a4f543e999c7a2b4ab49c724bf84ff4192f4c94",
+  "commit": "4aa8104df7e76fa2dcbf583dcec8052e81d915ef",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -18,9 +18,10 @@
       "repo_url": "https://github.com/pelican-plugins/graphviz",
       "dev_status": "5 - Production/Stable",
       "tests_exist": true,
-      "python_version": ">=3.8.1,<4.0",
+      "python_version": ">=3.10",
       "pelican_version": ">=4.5",
-      "_template": "https://github.com/getpelican/cookiecutter-pelican-plugin"
+      "_template": "https://github.com/getpelican/cookiecutter-pelican-plugin",
+      "_commit": "4aa8104df7e76fa2dcbf583dcec8052e81d915ef"
     }
   },
   "directory": null

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
 
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
 
@@ -55,7 +55,7 @@ jobs:
       - name: Set up Python & PDM
         uses: pdm-project/setup-pdm@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install dependencies
         run: pdm install
@@ -75,12 +75,12 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Check release
         id: check_release

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ ci:
 # See https://pre-commit.com/hooks.html for info on hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-added-large-files
       - id: check-ast
@@ -21,8 +21,8 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.2
+    rev: v0.14.2
     hooks:
-      - id: ruff
+      - id: ruff-check
       - id: ruff-format
         args: ["--check"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,16 +15,16 @@ classifiers = [
     "License :: OSI Approved :: GNU Affero General Public License v3",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
-requires-python = ">=3.9,<4.0"
+requires-python = ">=3.10"
 dependencies = [
     "pelican>=4.5",
     "py3dns>=3.2",
@@ -42,7 +42,7 @@ markdown = ["markdown>=3.4"]
 [dependency-groups]
 lint = [
     "invoke>=2.2",
-    "ruff>=0.9.1,<1.0.0",
+    "ruff>=0.14.2,<1.0.0",
 ]
 test = [
     "beautifulsoup4>=4.13",
@@ -60,7 +60,7 @@ source-includes = [
     "hello-world.png",
 ]
 includes = ["pelican/"]
-excludes = ["tasks.py"]
+excludes = ["**/.DS_Store"]
 
 [tool.autopub]
 project-name = "Graphviz"

--- a/tasks.py
+++ b/tasks.py
@@ -7,6 +7,11 @@ from shutil import which
 from invoke import task
 
 logger = logging.getLogger(__name__)
+level = logging.INFO
+logger.setLevel(level)
+console_handler = logging.StreamHandler()
+console_handler.setLevel(level)
+logger.addHandler(console_handler)
 
 PKG_NAME = "graphviz"
 PKG_PATH = Path(f"pelican/plugins/{PKG_NAME}")


### PR DESCRIPTION
Most notable change is adding explicit Python 3.14 support and dropping Python 3.9.